### PR TITLE
Allow ssl certificate validation bypass.

### DIFF
--- a/MediaBrowser.ApiInteraction/Net/HttpRequest.cs
+++ b/MediaBrowser.ApiInteraction/Net/HttpRequest.cs
@@ -14,6 +14,7 @@ namespace MediaBrowser.ApiInteraction.Net
         public HttpHeaders RequestHeaders { get; set; }
         public string Url { get; set; }
         public Stream RequestStream { get; set; }
+        public bool BypassSslCertificateValidation { get; set; }
 
         public int Timeout { get; set; }
 

--- a/MediaBrowser.ApiInteraction/Net/HttpWebRequestFactory.cs
+++ b/MediaBrowser.ApiInteraction/Net/HttpWebRequestFactory.cs
@@ -23,6 +23,11 @@ namespace MediaBrowser.ApiInteraction.Net
             request.Pipelined = true;
             request.Timeout = options.Timeout;
 
+            if (options.BypassSslCertificateValidation)
+            {
+                request.ServerCertificateValidationCallback += (sender, certificate, chain, errors) => true;
+            }
+
             // This is a hack to prevent KeepAlive from getting disabled internally by the HttpWebRequest
             var sp = request.ServicePoint;
             if (_httpBehaviorPropertyInfo == null)


### PR DESCRIPTION
Most people don't want to shell out the 10 or 15 bucks for an ssl cert just so people can't snoop on thier traffic. Until the EFF gets us free certs (https://www.eff.org/press/releases/new-free-certificate-authority-dramatically-increase-encrypted-internet-traffic) we will need a way to bypass server ssl certificate validation. 

This needs to be optional as there are some crazy people, such as myself, who actually purchased a certificate. This change needs to be vetted on Windows 8 and phone. I'm not 100% sure this API is supported and I don't have devices to test against.

This is incomplete. I'm still looking at the best way to expose this via the API. Does adding a property in connectionmanager seem appropriate?