### PR TITLE
Add null check for Device

### DIFF
--- a/MediaBrowser.ApiInteraction/BaseApiClient.cs
+++ b/MediaBrowser.ApiInteraction/BaseApiClient.cs
@@ -117,7 +117,7 @@ namespace MediaBrowser.ApiInteraction
         /// <value>The name of the device.</value>
         public string DeviceName
         {
-            get { return Device.DeviceName; }
+            get { return Device == null ? null : Device.DeviceName; }
         }
 
 
@@ -133,7 +133,7 @@ namespace MediaBrowser.ApiInteraction
         /// <value>The device id.</value>
         public string DeviceId
         {
-            get { return Device.DeviceId; }
+            get { return Device == null ? null : Device.DeviceId; }
         }
 
         /// <summary>


### PR DESCRIPTION
Otherwise [`ApiClient(ILogger, string, string, ICryptographyProvider)`](https://github.com/MediaBrowser/Emby.ApiClient/blob/1c1f3846f57e72da04d3ef672b7b54c05805b5fa/MediaBrowser.ApiInteraction/ApiClient.cs#L62) will fail with `NullReferenceException`.

Here's the stacktrace:

```
   at MediaBrowser.ApiInteraction.BaseApiClient.get_DeviceId() in c:\Dev\Emby.ApiClient\MediaBrowser.ApiInteraction\BaseApiClient.cs:line 136
   at MediaBrowser.ApiInteraction.BaseApiClient.get_AuthorizationParameter() in c:\Dev\Emby.ApiClient\MediaBrowser.ApiInteraction\BaseApiClient.cs:line 190
   at MediaBrowser.ApiInteraction.BaseApiClient.ResetHttpHeaders() in c:\Dev\Emby.ApiClient\MediaBrowser.ApiInteraction\BaseApiClient.cs:line 242
   at MediaBrowser.ApiInteraction.ApiClient..ctor(ILogger logger, String serverAddress, String accessToken, ICryptographyProvider cryptographyProvider) in c:\Dev\Emby.ApiClient\MediaBrowser.ApiInteraction\ApiClient.cs:line 71
...
```